### PR TITLE
Fix for Windows cmd

### DIFF
--- a/src/DefaultApplication.jl
+++ b/src/DefaultApplication.jl
@@ -16,7 +16,7 @@ function open(filename; wait = false)
         run(`xdg-open $(filename)`; wait = wait)
     elseif Sys.iswindows()
         cmd = get(ENV, "COMSPEC", "cmd")
-        run(`$(ENV["COMSPEC"]) /c start $(filename)`; wait = wait)
+        run(`$(cmd) /c start "" $(filename)`; wait = wait)
     else
         @warn("Opening files the default application is not supported on this OS.",
               KERNEL = Sys.KERNEL)


### PR DESCRIPTION
I was trying out Remark.jl on Windows and noticed that their call to `open`, which uses DefaultApplication.jl, didn't work.

From a bit of searching, it seems the `start` cmd command needs a title text (https://superuser.com/a/1335757). I'm not really sure whether `start` is even required here. Anyway, changing this worked for me. 
(On the other hand, I don't quite understand why it e.g. works fine with the .txt file from `DefaultApplication.test()` - which indeed it does.)

Thanks!