### PR TITLE
add WSL support

### DIFF
--- a/src/DefaultApplication.jl
+++ b/src/DefaultApplication.jl
@@ -19,15 +19,13 @@ function open(filename; wait = false)
     @static if Sys.isapple()
         run(`open $(filename)`; wait = wait)
     elseif _is_wsl
-        # Powershell can open *relative* paths in WSL, hence basename/dirname here.
+        # Powershell can open *relative* paths in WSL, hence using relpath
         # Could use wslview instead, but powershell is more universally available.
         # Could use cmd + wslpath instead, but cmd complains about the working directory.
         # Quotes around the filename are to deal with spaces.
-        realfile = realpath(filename)
-        dir = dirname(realfile)
-        base = basename(realfile)
-        cmd = `powershell.exe -NoProfile -NonInteractive -Command start \"$(base)\"`
-        run(Cmd(cmd; dir = dir); wait = wait)
+        relfile = relpath(filename)
+        cmd = `powershell.exe -NoProfile -NonInteractive -Command start \"$(relfile)\"`
+        run(cmd; wait = wait)
     elseif Sys.islinux() || Sys.isbsd()
         run(`xdg-open $(filename)`; wait = wait)
     elseif Sys.iswindows()

--- a/src/DefaultApplication.jl
+++ b/src/DefaultApplication.jl
@@ -3,8 +3,10 @@ module DefaultApplication
 import InteractiveUtils
 
 # based on https://stackoverflow.com/questions/38086185/
-const _is_wsl = Sys.islinux() && isfile("/proc/sys/kernel/osrelease") &&
-    occursin(r"microsoft|wsl"i, read("/proc/sys/kernel/osrelease", String))
+const _is_wsl = Sys.islinux() &&
+    let osrelease = "/proc/sys/kernel/osrelease"
+        isfile(osrelease) && occursin(r"microsoft|wsl"i, read(osrelease, String))
+    end
 
 """
     DefaultApplication.open(filename; wait = false)

--- a/src/DefaultApplication.jl
+++ b/src/DefaultApplication.jl
@@ -19,9 +19,15 @@ function open(filename; wait = false)
     @static if Sys.isapple()
         run(`open $(filename)`; wait = wait)
     elseif _is_wsl
-        # wslview doesn't like absolute paths for some reason, hence basename/dirname here
-        absfile = abspath(filename)
-        run(Cmd(`wslview $(basename(absfile))`; dir = dirname(absfile)); wait = wait)
+        # Powershell can open *relative* paths in WSL, hence basename/dirname here.
+        # Could use wslview instead, but powershell is more universally available.
+        # Could use cmd + wslpath instead, but cmd complains about the working directory.
+        # Quotes around the filename are to deal with spaces.
+        realfile = realpath(filename)
+        dir = dirname(realfile)
+        base = basename(realfile)
+        cmd = `powershell.exe -NoProfile -NonInteractive -Command start \"$(base)\"`
+        run(Cmd(cmd; dir = dir); wait = wait)
     elseif Sys.islinux() || Sys.isbsd()
         run(`xdg-open $(filename)`; wait = wait)
     elseif Sys.iswindows()

--- a/src/DefaultApplication.jl
+++ b/src/DefaultApplication.jl
@@ -2,6 +2,10 @@ module DefaultApplication
 
 import InteractiveUtils
 
+# based on https://stackoverflow.com/questions/38086185/
+const _is_wsl = Sys.islinux() && isfile("/proc/sys/kernel/osrelease") &&
+    occursin(r"microsoft|wsl"i, read("/proc/sys/kernel/osrelease", String))
+
 """
     DefaultApplication.open(filename; wait = false)
 
@@ -12,6 +16,10 @@ The argument `wait` is passed to `run`.
 function open(filename; wait = false)
     @static if Sys.isapple()
         run(`open $(filename)`; wait = wait)
+    elseif _is_wsl
+        # wslview doesn't like absolute paths for some reason, hence basename/dirname here
+        absfile = abspath(filename)
+        run(Cmd(`wslview $(basename(absfile))`; dir = dirname(absfile)); wait = wait)
     elseif Sys.islinux() || Sys.isbsd()
         run(`xdg-open $(filename)`; wait = wait)
     elseif Sys.iswindows()


### PR DESCRIPTION
This PR adds support for Windows Subsystem for Linux (WSL).

Before:
```julia-repl
julia> DefaultApplication.open("test.html", wait=true)
ERROR: IOError: could not spawn `xdg-open test.html`: no such file or directory (ENOENT)
[...]
```

Even if you install `xdg-open` it fails because it opens a browser but gives it the Linux path, which is not understood from Windows:
```julia-repl
julia> DefaultApplication.open("test.html", wait=true)
Start : This command cannot be run due to the error: The system cannot find the file specified.
At line:1 char:1
+ Start "/home/cjdoris/test.html"
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Start-Process], InvalidOperationException
    + FullyQualifiedErrorId : InvalidOperationException,Microsoft.PowerShell.Commands.StartProcessCommand

Process(`xdg-open test.html`, ProcessExited(0))
```

After:
```julia-repl
julia> DefaultApplication.open("test.html", wait=true)
Process(setenv(`wslview test.html`; dir="/home/cjdoris"), ProcessExited(0))
```